### PR TITLE
fix github link to spacedrop

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ meteor add timbrandin:blaze-react
 ## Demo
 
 * Add new demo here... I.e. Microscope.
-* http://spacedropcms.org (https://github.com/spacedrop/spacedropcms-org)
+* http://spacedropcms.org (https://github.com/spacedrop/spacedrop)
 * http://timbrandin.com (https://github.com/timbrandin/timbrandin)
 
 ## Getting started


### PR DESCRIPTION
Spacedrop github project same seems to have change so the link point to a 404 page not found. Juste change to the new url
